### PR TITLE
Team name backgrounds

### DIFF
--- a/HTML Packs/DEFAULT HTML/html/heroes1.html
+++ b/HTML Packs/DEFAULT HTML/html/heroes1.html
@@ -81,6 +81,8 @@
       animation: topmove 1.34s;
       animation-fill-mode: backwards;
       animation-delay: 0.5s;
+
+   			background-color: white;
     }
 
     .logo {

--- a/HTML Packs/DEFAULT HTML/html/heroes2.html
+++ b/HTML Packs/DEFAULT HTML/html/heroes2.html
@@ -81,6 +81,8 @@
       animation: topmove 1.34s;
       animation-fill-mode: backwards;
       animation-delay: 0.5s;
+     
+  			 background-color: white;
     }
 
     .logo {


### PR DESCRIPTION
Adds a white background to the team scenes (heroes1/2). This should give better visibility in instances where the default background video is not used.

Currently, there is no preset color that handles text backgrounds, so once a preset is created there will be a chance to make this customizable.