### PR TITLE
Update winner_page.html

### DIFF
--- a/HTML Packs/DEFAULT HTML/html/winner_page.html
+++ b/HTML Packs/DEFAULT HTML/html/winner_page.html
@@ -85,7 +85,7 @@ If you don't use any URL parameters, the transition will display the branding lo
 
 		div.winnertext {
 			position: absolute;
-			bottom: 250px;
+			bottom: 75px;
 			width: 100%;
 
 			display: flex;
@@ -119,7 +119,7 @@ If you don't use any URL parameters, the transition will display the branding lo
 
 			animation: textslideease 1s;
 			animation-fill-mode: backwards;
-			animation-delay: 0.5s;
+			animation-delay: 1.2s;
 			-webkit-animation-timing-function: cubic-bezier(0, 0, 0, 1);
 		}
 
@@ -136,7 +136,7 @@ If you don't use any URL parameters, the transition will display the branding lo
    			background-repeat: no-repeat;
    			background-position: center;
    			animation: slideease 1s forwards;
-   			animation-delay: 0.3s;
+   			animation-delay: 1s;
 		}
 
 


### PR DESCRIPTION
Change animation timing and sizing of elements:

- Fade-in from right will now be visible upon loading the scene when default stinger is used.
- Winning team logo size has been increased to use more of the available screen space
- Winning team name has been shifted down further to accommodate the larger logo size